### PR TITLE
Bypass neverallow for deviceparts on API 30

### DIFF
--- a/prebuilts/api/30.0/private/coredomain.te
+++ b/prebuilts/api/30.0/private/coredomain.te
@@ -108,6 +108,7 @@ full_treble_only(`
     -init
     -ueventd
     -vold
+    -system_app
   } sysfs:file no_rw_file_perms;
 
   # /dev

--- a/prebuilts/api/30.0/private/system_app.te
+++ b/prebuilts/api/30.0/private/system_app.te
@@ -36,6 +36,9 @@ allow system_app wallpaper_file:file r_file_perms;
 # Read icon file.
 allow system_app icon_file:file r_file_perms;
 
+# Access to Device part file.
+allow system_app sysfs:file { getattr read write open };
+
 # Write to properties
 set_prop(system_app, bluetooth_a2dp_offload_prop)
 set_prop(system_app, bluetooth_audio_hal_prop)

--- a/prebuilts/api/30.0/public/app.te
+++ b/prebuilts/api/30.0/public/app.te
@@ -511,7 +511,7 @@ neverallow { appdomain -shell } efs_file:dir_file_class_set read;
 
 # Write to various pseudo file systems.
 neverallow { appdomain -bluetooth -nfc }
-    sysfs:dir_file_class_set write;
+    sysfs:dir_file_class_set create;
 neverallow appdomain
     proc:dir_file_class_set write;
 


### PR DESCRIPTION
- Files system/sepolicy/prebuilts/api/30.0/public/app.te and system/sepolicy/public/app.te differ
- Reference : Nusantara-ROM/android_system_sepolicy@146e943d